### PR TITLE
Enable subdomain multisite installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ All Ansible configuration is done in [YAML](http://en.wikipedia.org/wiki/YAML).
 
 This playbook assumes your WordPress configuration already has multisite set up. If not, ensure the following values are placed somewhere in  wp-config.php (or `config/application.php` if you're using [bedrock](https://github.com/roots/bedrock)) *before running the `wordpress-sites` role*:
 
-```
-<?php
+```php
 /* Multisite */
 define('WP_ALLOW_MULTISITE', true);
 define('MULTISITE', true);

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ All Ansible configuration is done in [YAML](http://en.wikipedia.org/wiki/YAML).
   * `wp_home` (required) - `WP_HOME` constant or `home` option (default: none)
   * `wp_siteurl` (required) - `WP_SITEURL` constant or `siteurl` option (default: none)
   * `wp_env` (required) - WordPress environment (default: none)
-  * `domain_current_site` (optional|required for multisite) - sets DOMAIN_CURRENT_SITE for multisite
+  * `domain_current_site` (optional|required for multisite) - sets `DOMAIN_CURRENT_SITE` for multisite
   * `db_name` (optional) - name of database (default: `site_name`)
   * `db_user` (required) - database user name (default: none)
   * `db_password` (required) - database user password (default: none)
@@ -137,9 +137,10 @@ All Ansible configuration is done in [YAML](http://en.wikipedia.org/wiki/YAML).
 
 ## Multisite
 
-This playbook assumes your WordPress configuration already has multisite set up. If not, ensure the following values are placed somewhere in  wp-config.php ( or `config/application.php` if you're using [bedrock](https://github.com/roots/bedrock) ) *before running the `wordpress-sites` role*:
+This playbook assumes your WordPress configuration already has multisite set up. If not, ensure the following values are placed somewhere in  wp-config.php (or `config/application.php` if you're using [bedrock](https://github.com/roots/bedrock)) *before running the `wordpress-sites` role*:
 
 ```
+<?php
 /* Multisite */
 define('WP_ALLOW_MULTISITE', true);
 define('MULTISITE', true);

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ Note: The full paths to these directories must not contain spaces or else Ansibl
 ### Development
 
 1. Edit `group_vars/development` and add your WordPress site(s). See [Options](#options) below for details.
-2. Optionally add any dev hostnames to your local `/etc/hosts` file (or use the [hostsupdater plugin](https://github.com/cogitatio/vagrant-hostsupdater)).
-3. Run `vagrant up`.
+2. Run `vagrant up`.
 
 Vagrant automatically reads `group_vars/development` and creates a synced folder for each of the sites.
 
@@ -130,10 +129,26 @@ All Ansible configuration is done in [YAML](http://en.wikipedia.org/wiki/YAML).
   * `wp_home` (required) - `WP_HOME` constant or `home` option (default: none)
   * `wp_siteurl` (required) - `WP_SITEURL` constant or `siteurl` option (default: none)
   * `wp_env` (required) - WordPress environment (default: none)
+  * `domain_current_site` (optional|required for multisite) - sets DOMAIN_CURRENT_SITE for multisite
   * `db_name` (optional) - name of database (default: `site_name`)
   * `db_user` (required) - database user name (default: none)
   * `db_password` (required) - database user password (default: none)
   * `db_host` (required) - database host (default: `localhost`)
+
+## Multisite
+
+This playbook assumes your WordPress configuration already has multisite set up. If not, ensure the following values are placed somewhere in  wp-config.php ( or `config/application.php` if you're using [bedrock](https://github.com/roots/bedrock) ) *before running the `wordpress-sites` role*:
+
+```
+/* Multisite */
+define('WP_ALLOW_MULTISITE', true);
+define('MULTISITE', true);
+define('SUBDOMAIN_INSTALL', true); // Set to false if using subdirectories
+define('DOMAIN_CURRENT_SITE', getenv('DOMAIN_CURRENT_SITE'));
+define('PATH_CURRENT_SITE', '/');
+define('SITE_ID_CURRENT_SITE', 1);
+define('BLOG_ID_CURRENT_SITE', 1);
+```
 
 ## Security
 
@@ -191,5 +206,4 @@ You can read the role documentation for `fail2ban` [here](roles/fail2ban/README.
 
 ## Todo
 
-* Multisite: basic support is included but not yet complete. There are issues with doing a network install from scratch via WP-CLI.
-* Nginx: configuration needs more options and advanced setups like static files and subdomain multisite support.
+* Nginx: configuration needs more options and advanced setups like static files.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,12 +25,19 @@ Vagrant.configure('2') do |config|
 
   config.vm.hostname = main_site['site_hosts'].first
 
-  if Vagrant.has_plugin? 'vagrant-hostsupdater'
-    host_aliases = other_sites.flat_map { |site| site['site_hosts'] }
-    config.hostsupdater.aliases = host_aliases - [config.vm.hostname]
+  if Vagrant.has_plugin? 'landrush'
+    config.landrush.enabled = true
+    config.landrush.tld = main_site['site_hosts'].first
+
+    host_aliases = wordpress_sites.flat_map { |site| site['site_hosts'] }
+    host_aliases.each do |site|
+      if site != main_site['site_hosts'].first and !site.include? "*"
+        config.landrush.host site, '192.168.50.5'
+      end
+    end
   else
-    puts 'vagrant-hostsupdater missing, please install the plugin:'
-    puts 'vagrant plugin install vagrant-hostsupdater'
+    puts 'landrush missing, please install the plugin:'
+    puts 'vagrant plugin install landrush'
   end
 
   if Vagrant::Util::Platform.windows?

--- a/group_vars/development
+++ b/group_vars/development
@@ -4,6 +4,7 @@ wordpress_sites:
   - site_name: example.dev
     site_hosts:
       - example.dev
+      - '*.example.dev' # remove if using a subdirectory multisite install
     local_path: '../example.dev' # path targeting local project directory (relative to root/Vagrantfile)
     user: vagrant
     group: www-data
@@ -14,7 +15,8 @@ wordpress_sites:
     admin_email: admin@example.dev
     system_cron: true
     multisite:
-      enabled: false
+      enabled: true
+      subdomain: true
     env:
       wp_home: http://example.dev
       wp_siteurl: http://example.dev/wp
@@ -22,6 +24,7 @@ wordpress_sites:
       db_name: example_dev
       db_user: example_dbuser
       db_password: example_dbpassword
+      domain_current_site: example.dev # required for multisite
 
 php_error_reporting: 'E_ALL'
 php_display_errors: 'On'

--- a/roles/wordpress-sites/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-sites/templates/wordpress-site.conf.j2
@@ -1,7 +1,8 @@
 server {
   set $site_name {{ item.site_name }};
 
-  listen *:80;
+  listen 80;
+
   server_name  {{ item.site_hosts | join(' ') }};
   access_log   {{ www_root }}/{{ item.site_name }}/logs/{{ item.site_name }}.access.log;
   error_log    {{ www_root }}/{{ item.site_name }}/logs/{{ item.site_name }}.error.log;
@@ -11,21 +12,28 @@ server {
 
   charset utf-8;
 
-  {% if item.env.wp_env == 'development' -%}
-    # See Virtualbox section at http://wiki.nginx.org/Pitfalls
-    sendfile off;
-  {%- endif %}
+{% if item.env.wp_env == 'development' -%}
+  # See Virtualbox section at http://wiki.nginx.org/Pitfalls
+  sendfile off;
+{%- endif %}
 
-  {% if item.multisite.enabled | default(false) -%}
-    include wordpress_multisite_subdirectories.conf;
+{% if item.multisite.enabled | default(false) %}
+  {% if item.multisite.subdomains | default(false) %}
+
+  rewrite ^/(wp-.*.php)$ /wp/$1 last;
+  rewrite ^/(wp-(content|admin|includes).*) /wp/$1 last;
+  {%- else %}
+  include wordpress_multisite_subdirectories.conf;
   {%- endif %}
+{%- endif %}
+
 
   include wordpress.conf;
 }
 
-{% for host in item.site_hosts if strip_www %}
+{% for host in item.site_hosts if strip_www and host.split('.')[0] != '*' %}
 server {
-  listen *:80;
+  listen 80;
   server_name www.{{ host }};
   return 301 $scheme://{{ host }}$request_uri;
 }


### PR DESCRIPTION
Dropped dependency on `vagrant-hostsupdater` in favor of [`landrush`](https://github.com/phinze/landrush). `landrush` spins up a small dns server that allows us to use wildcard subdomains, a requirement for subdomain multisite installs. Let me know what you think!