### PR TITLE
php5-fpm uses realpath (fixes #134)

### DIFF
--- a/roles/nginx/templates/wordpress.conf.j2
+++ b/roles/nginx/templates/wordpress.conf.j2
@@ -5,7 +5,8 @@ location / {
 location ~ \.php$ {
   try_files $uri =404;
   include fastcgi_params;
-  fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+  fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+  fastcgi_param DOCUMENT_ROOT $realpath_root;
   fastcgi_pass unix:/var/run/php5-fpm-$site_name.sock;
   client_max_body_size 0;
 }


### PR DESCRIPTION
From https://github.com/roots/bedrock/issues/134#issuecomment-70996256

> php5 opcache doesnt resolve symlinks for file paths (APC and others did), so when you deploy a new version opcache still see the same path (/srv/www/mysite/current/web/myfile.php) so it still serve the old cached file.