### PR TITLE
php5-xdebug role

### DIFF
--- a/group_vars/development
+++ b/group_vars/development
@@ -29,3 +29,12 @@ php_display_startup_errors: 'On'
 php_track_errors: 'On'
 php_mysqlnd_collect_memory_statistics: 'On'
 php_opcache_enable: 0
+
+xdebug_install: false
+php_xdebug_remote_enable: true
+php_xdebug_remote_connect_back: true
+php_xdebug_remote_host: localhost
+php_xdebug_remote_port: 9000
+php_xdebug_remote_log: /tmp/xdebug.log
+php_xdebug_idekey: XDEBUG
+php_max_nesting_level: 200

--- a/roles/php5-xdebug/.travis.yml
+++ b/roles/php5-xdebug/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+
+php:
+  - 5.5
+
+before_install:
+  - sudo apt-get update  -y -q
+
+install:
+  - sudo apt-get install python-pip -y
+  - sudo pip install ansible==1.4.0
+
+script:
+  - cd tests
+  - ansible-playbook -i inventory playbook.yml --syntax-check
+  - ansible-playbook -i inventory playbook.yml --connection=local --sudo
+  - >
+    ansible-playbook -i inventory playbook.yml --connection=local --sudo
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)

--- a/roles/php5-xdebug/README.md
+++ b/roles/php5-xdebug/README.md
@@ -1,0 +1,49 @@
+# Ansible Role: PHP-XDebug
+
+[![Build Status](https://travis-ci.org/MaximeThoonsen/ansible-role-php-xdebug.svg?branch=master)](https://travis-ci.org/MaximeThoonsen/ansible-role-php-xdebug)
+
+Installs PHP [XDebug](http://xdebug.org/) on Ubuntu Trusty(14.04) or Precise(12.04).
+
+## Requirements
+
+None.
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `vars/main.yml`):
+
+    php_xdebug_remote_enable: "false"
+
+Whether remote debugging is enabled.
+
+    php_xdebug_remote_connect_back: "false"
+
+If this is set to true, Xdebug will respond to any request from any IP address; use only for local development on non-public installations!
+
+    php_xdebug_remote_host: localhost
+    php_xdebug_remote_port: "9000"
+
+The host and port on which Xdebug will listen.
+
+    php_xdebug_remote_log: /tmp/xdebug.log
+
+The location of the xdebug log (useful if you're having trouble connecting).
+
+    php_xdebug_idekey: XDEBUG
+
+The IDE key to use in the URL when making Xdebug requests (e.g. `http://example.local/?XDEBUG_SESSION_START=XDEBUG`).
+
+## Example Playbook
+
+    - hosts: webservers
+      roles:
+        - { role: MaximeThoonsen.php5-xdebug }
+
+## License
+
+MIT
+
+## Author Information
+
+This role was created in 2014 by [Maxime Thoonsen](https://twitter.com/MaximeThoonsen).
+It was forked from [Jeff Geerling's role](https://github.com/geerlingguy/ansible-role-php-xdebug)

--- a/roles/php5-xdebug/defaults/main.yml
+++ b/roles/php5-xdebug/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+php_xdebug_remote_enable: "false"
+php_xdebug_remote_connect_back: "false"
+php_xdebug_remote_host: localhost
+php_xdebug_remote_port: "9000"
+php_xdebug_remote_log: /tmp/xdebug.log
+php_xdebug_idekey: XDEBUG
+php_max_nesting_level: 200

--- a/roles/php5-xdebug/meta/main.yml
+++ b/roles/php5-xdebug/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Maxime Thoonsen
+  description: PHP XDebug for Ubuntu Trusty and Precise
+  company: "Theodo"
+  license: "license (BSD, MIT)"
+  min_ansible_version: 1.4
+  platforms:
+  - name: Ubuntu
+    versions:
+    - Trusty
+    - Precise
+  categories:
+    - development
+    - web

--- a/roles/php5-xdebug/tasks/main.yml
+++ b/roles/php5-xdebug/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: php5 - install xdebug
+  apt: pkg=php5-xdebug state=latest update_cache=yes
+
+- name: Copy xdebug INI into mods-available folder.
+  template: >
+    src=xdebug.ini.j2
+    dest=/etc/php5/mods-available/xdebug.ini
+    owner=root group=root mode=644
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'
+
+- name: Copy xdebug INI into conf.d folder.
+  template: >
+    src=xdebug.ini.j2
+    dest=/etc/php5/conf.d/xdebug.ini
+    owner=root group=root mode=644
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'precise'

--- a/roles/php5-xdebug/templates/xdebug.ini.j2
+++ b/roles/php5-xdebug/templates/xdebug.ini.j2
@@ -1,0 +1,10 @@
+[XDebug]
+zend_extension="xdebug.so"
+xdebug.remote_enable={{ php_xdebug_remote_enable }}
+xdebug.remote_connect_back={{ php_xdebug_remote_connect_back }}
+xdebug.remote_host={{ php_xdebug_remote_host }}
+xdebug.remote_port={{ php_xdebug_remote_port }}
+xdebug.remote_handler="dbgp"
+xdebug.remote_log={{ php_xdebug_remote_log }}
+xdebug.idekey="{{ php_xdebug_idekey }}"
+xdebug.max_nesting_level = {{ php_max_nesting_level }}

--- a/roles/php5-xdebug/tests/Makefile
+++ b/roles/php5-xdebug/tests/Makefile
@@ -1,0 +1,13 @@
+test_ubuntu-14.04:
+	VM_BOX='ubuntu/trusty64' vagrant up --provision
+	VM_BOX='ubuntu/trusty64' vagrant provision
+	VM_BOX='ubuntu/trusty64' vagrant destroy -f
+
+test_ubuntu-12.04:
+	VM_BOX='hashicorp/precise64' vagrant up --provision
+	VM_BOX='hashicorp/precise64' vagrant provision
+	VM_BOX='hashicorp/precise64' vagrant destroy -f
+
+test_all:
+	make test_ubuntu-12.04
+	make test_ubuntu-14.04

--- a/roles/php5-xdebug/tests/Vagrantfile
+++ b/roles/php5-xdebug/tests/Vagrantfile
@@ -1,0 +1,12 @@
+$VM_BOX = ENV.has_key?('VM_BOX') ? ENV['VM_BOX'] : 'ubuntu/trusty64'
+
+Vagrant.configure('2') do |config|
+  config.vm.box = $VM_BOX
+
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = 'playbook.yml'
+    ansible.extra_vars = { ansible_ssh_user: 'vagrant', vagrant: true }
+
+    ansible.verbose = 'v'
+  end
+end

--- a/roles/php5-xdebug/tests/inventory
+++ b/roles/php5-xdebug/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/php5-xdebug/tests/playbook.yml
+++ b/roles/php5-xdebug/tests/playbook.yml
@@ -1,0 +1,4 @@
+- hosts: all
+  sudo: true
+  roles:
+    - { role: ../../ansible-role-php-xdebug, tags: xdebug }

--- a/site.yml
+++ b/site.yml
@@ -11,6 +11,7 @@
     - { role: mariadb, tags: [mariadb] }
     - { role: ssmtp, tags: [ssmtp mail] }
     - { role: php, tags: [php] }
+    - { role: php5-xdebug, tags: [xdebug], when: xdebug_install | default(False) }
     - { role: nginx, tags: [nginx] }
     - { role: memcached, tags: [memcached] }
     - { role: composer, tags: [composer] }


### PR DESCRIPTION
Added php5-xdebug role from https://galaxy.ansible.com/list#/roles/1133 (as mentioned this [this thread](https://discourse.roots.io/t/found-an-xdebug-ansible-role-installer-wondering-how-it-might-work-with-bedrock/2901))

Change ```xdebug_install: false``` in group_vars/development to enable.

Fixes https://github.com/roots/bedrock-ansible/issues/42