### PR TITLE
Fixes #144 - HHVM mysql fix

### DIFF
--- a/roles/hhvm/tasks/main.yml
+++ b/roles/hhvm/tasks/main.yml
@@ -20,6 +20,12 @@
 - name: HHVM server.ini
   template: src=server.ini.j2 dest=/etc/hhvm/server.ini
 
+- name: HHVM php.ini
+  template: src=php.ini.j2 dest=/etc/hhvm/php.ini
+
+- name: Symlink mysql.sock for HHVM
+  file: src=/var/run/mysqld/mysqld.sock dest=/tmp/mysql.sock owner=mysql group=mysql state=link force=yes
+
 - name: Start HHVM service
   service: name=hhvm state=started enabled=true
 

--- a/roles/hhvm/templates/php.ini.j2
+++ b/roles/hhvm/templates/php.ini.j2
@@ -1,0 +1,11 @@
+; php options
+session.save_handler = files
+session.save_path = /var/lib/php5
+session.gc_maxlifetime = 1440
+
+; hhvm specific
+hhvm.log.level = Warning
+hhvm.log.always_log_unhandled_exceptions = true
+hhvm.log.runtime_error_reporting_level = 8191
+hhvm.mysql.socket = /var/run/mysqld/mysqld.sock
+hhvm.mysql.typed_results = false

--- a/roles/php/templates/php.ini.j2
+++ b/roles/php/templates/php.ini.j2
@@ -28,4 +28,5 @@ opcache.fast_shutdown = {{ php_opcache_fast_shutdown }}
 hhvm.log.level = Warning
 hhvm.log.always_log_unhandled_exceptions = true
 hhvm.log.runtime_error_reporting_level = 8191
+hhvm.mysql.socket = /var/run/mysqld/mysqld.sock
 hhvm.mysql.typed_results = false


### PR DESCRIPTION
HHVM 3.6.0 has a bug to do with the MySQL socket path. Right now the only solution for WordPress (since it uses PDO) is to symlink the socket.

See https://github.com/facebook/hhvm/issues/4987