### PR TITLE
SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This playbook will install the common LEMP (Linux/Nginx/MySQL/PHP) stack with PH
   * [WP Sites](#wp-sites)
   * [Mail](#mail)
 * [HHVM](#hhvm)
+* [SSL Support](#ssl)
 * [Security](#security)
   * [Locking Down Root](#locking-down-root)
   * [Configuration Files](#configuration-files)
@@ -132,6 +133,10 @@ Note: you can always set the box back to the base Ubuntu one if you prefer with 
 The only caveat is that it's not set up to seamlessly switch between the two on already provisioned machines. You'll either need to do some manual cleanup (like removing php5.6) or just re-create your machine.
 
 See `roles/hhvm/README.md` for more information on running HHVM with WordPress.
+
+## SSL Support
+
+You can enable the SSL support setting SSL to true in `group_vars/all` where you can also specify the .key and .crt files's local path and names.
 
 ## Options
 

--- a/group_vars/all
+++ b/group_vars/all
@@ -10,6 +10,11 @@ mail_password: smtp_password
 
 hhvm: false
 
+ssl: true
+nginx_ssl_local_path: ~/keys/
+nginx_ssl_crt: sslkey.crt
+nginx_ssl_key: sslkey.key
+
 sudoers:
   - user: admin
     groups: [sudo]

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,3 +1,3 @@
 keyserver_fingerprint: "0xcbcb082a1bb943db"
-mirror: nyc2.mirrors.digitalocean.com
+mirror: "ftp.nluug.nl/db"
 version: "10.0"

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -23,6 +23,17 @@
 - name: Disable default server
   file: path=/etc/nginx/sites-enabled/default state=absent
 
+- name: ensure nginx ssl directory is created
+  file: path=/etc/nginx/ssl state=directory
+  when: ssl
+
+- name: ensure nginx ssl certificate and key are created
+  copy: src={{ nginx_ssl_local_path }}/{{ item }} dest=/etc/nginx/ssl/{{ item }} mode=0600
+  with_items:
+    - "{{ nginx_ssl_crt }}"
+    - "{{ nginx_ssl_key }}"
+  when: ssl
+  
 - name: Create base WordPress config
   template: src=wordpress.conf.j2 dest=/etc/nginx/wordpress.conf
 

--- a/roles/wordpress-sites/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-sites/templates/wordpress-site.conf.j2
@@ -1,5 +1,9 @@
 server {
-  listen *:80;
+  {% if ssl %}
+  listen 443 ssl;
+  {% else %}
+  listen 80;
+  {% endif %}
   server_name  {{ item.site_hosts | join(' ') }};
   access_log   {{ www_root }}/{{ item.site_name }}/logs/{{ item.site_name }}.access.log;
   error_log    {{ www_root }}/{{ item.site_name }}/logs/{{ item.site_name }}.error.log;
@@ -8,6 +12,12 @@ server {
   index index.php;
 
   charset utf-8;
+
+  {% if ssl %}
+  include /etc/nginx/h5bp/directive-only/ssl.conf;
+  ssl_certificate           /etc/nginx/ssl/{{ nginx_ssl_crt }};
+  ssl_certificate_key       /etc/nginx/ssl/{{ nginx_ssl_key }};
+  {% endif %}
 
   {% if item.env.wp_env == 'development' -%}
     # See Virtualbox section at http://wiki.nginx.org/Pitfalls
@@ -23,8 +33,22 @@ server {
 
 {% for host in item.site_hosts if strip_www %}
 server {
-  listen *:80;
+  {% if ssl %}
+  listen 443 ssl;
+  ssl_certificate           /etc/nginx/ssl/{{ nginx_ssl_crt }};
+  ssl_certificate_key       /etc/nginx/ssl/{{ nginx_ssl_key }};
+  {% else %}
+  listen 80;
+  {% endif %}
   server_name www.{{ host }};
   return 301 $scheme://{{ host }}$request_uri;
 }
 {% endfor %}
+
+{% if ssl %}
+server {
+  listen 80;
+  server_name {{ host }};
+  return 301 https://$host$request_uri;
+}
+{% endif %}


### PR DESCRIPTION
This fork introduce a basic SSL support. 

The certificates are required and need to be on the host machine (I use the same 2 auto-signed certificates for all my development virtual machines). Yo can specify the local path and certificates' names in group_vars/all

