### PR TITLE
Add rollback role

### DIFF
--- a/roles/rollback/tasks/main.yml
+++ b/roles/rollback/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- include: user-release.yml
+  when: release is defined
+
+- include: prior-release.yml
+  when: release is not defined
+
+- name: Check whether target release was from a successful deploy
+  stat: path="{{ new_release_path }}/DEPLOY_UNFINISHED"
+  register: target
+
+- name: Fail if target release was from failed deploy
+  fail: msg="Cannot switch to release at {{ new_release_path }}. It is from an unfinished deploy.
+        You may manually specify a different release using --extra-vars='release=12345678901234'."
+  when: target.stat.exists | default(False)
+
+- name: Link 'current' directory to target release
+  file: path="{{ project_root }}/current" src="{{ new_release_path }}" state=link

--- a/roles/rollback/tasks/prior-release.yml
+++ b/roles/rollback/tasks/prior-release.yml
@@ -1,0 +1,21 @@
+---
+- name: Get list position of current symlinked release
+  shell: "ls releases | grep -n $(basename $(readlink current)) | cut -f1 -d:"
+  args:
+    chdir: "{{ project_root }}"
+  register: current_release_position
+
+- name: Fail if current release is the oldest available release
+  fail: msg="Currently symlinked to earliest available release. Cannot rollback.
+        You may manually specify a different release using --extra-vars='release=12345678901234'."
+  when: current_release_position.stdout_lines[0] == "1"
+
+- name: Collect list of releases
+  command: ls releases
+  args:
+    chdir: "{{ project_root }}"
+  register: releases
+
+- name: Create new_release_path variable
+  set_fact:
+    new_release_path: "{{ project_root }}/releases/{{ releases.stdout_lines[(current_release_position.stdout_lines[0] | int - 2)] }}"

--- a/roles/rollback/tasks/user-release.yml
+++ b/roles/rollback/tasks/user-release.yml
@@ -1,0 +1,18 @@
+---
+- name: Check whether user-specified release exists
+  stat: path="{{ project_root }}/releases/{{ release }}"
+  register: specified
+
+- name: Get name of current symlinked release
+  shell: "basename $(readlink current)"
+  args:
+    chdir: "{{ project_root }}"
+  register: current_release
+
+- name: Fail if user-specified release doesn't exist or is already active
+  fail: msg="Cannot switch to release {{ release }}. Either it does not exist or it is the active release."
+  when: specified.stat.isdir | default(False) == False or current_release.stdout_lines[0] == release
+
+- name: Create new_release_path variable
+  set_fact:
+    new_release_path: "{{ project_root }}/releases/{{ release }}"

--- a/rollback.yml
+++ b/rollback.yml
@@ -1,0 +1,10 @@
+---
+- name: Rollback a Deploy
+  hosts: web
+  remote_user: "{{ web_user }}"
+
+  vars:
+    project_root: "{{ www_root }}/{{ site }}"
+
+  roles:
+    - rollback


### PR DESCRIPTION
No pressure to use this. I just thought I'd try a draft. Might be nice with #95 

**Roll back.** This is for rolling back to the previous deploy/release (default), or to any existing deploy you specify. It is **not** for when a deploy fails because the deploy role deploys nothing if it fails at any point.

**Use.** We could write a bash wrapper script, but for now...
- **Roll back to previous:** `ansible-playbook -i hosts/staging rollback.yml --extra-vars="site=staging.example.com"`
- **Roll back/forward to existing release:** `ansible-playbook -i hosts/staging rollback.yml --extra-vars="site=staging.example.com release=20150401173849"` If a site runs on multiple servers, I suspect release names (time stamps) would vary slightly across servers. If so, the deploy role could maybe put a single time stamp into deploy_helper's `release` parameter at initiation.

**Assumptions.** The janky "Get list position of current symlinked release" task assumes the `releases` directory has no contents but releases, in chronological list order. In the future, the task could grab release names/sequence from the deploy history log.