### PR TITLE
Add option for local build commands

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -37,9 +37,9 @@ project_composer_vendor_path: vendor
 #   - name: "some_file"           // <- optional, for your own reference and readability
 #     src: "local-path-to-file"   // <- relative or absolute, just like Ansible
 #     dest: "remote-path-to-file"
-#   - name: "some_other_file"
-#     src: "local-path-to-other-file"
-#     dest: "remote-path-to-other-file"
+#   - name: compiled theme assets
+#     src: ../example.dev/web/app/themes/sage/dist
+#     dest: web/app/themes/sage
 project_files: []
 
 # All the templates to copy to the remote system on deploy. These could contain config files.
@@ -66,12 +66,18 @@ project_environment: {}
 
 # There are a few moments in this role where arbitrary command(s) can be run. These commands receive
 # the "project_environment" so deploys for different stages can be done by changing this.
-# Each command is a dict with a `cmd` and an optional `path` which is relative to the `new_release_path`.
-# Example:
+# Each command is a dict with a `cmd` and an optional `path`. The `path` is relative to the
+# local bedrock-ansible directory (for `project_pre_build_commands_local`) or relative to the
+# `new_release_path` on the remote server (for `project_pre_build_commands` and `project_post_build_commands`).
+# Examples:
+# project_pre_build_commands_local:
+#   - path: ../example.dev/web/app/themes/sage
+#     cmd: gulp --production
 # project_post_build_commands:
 #   - path: web/app/themes/mytheme
 #     cmd: npm install && gulp --production
 #   - cmd: wp db import posts.sql
+project_pre_build_commands_local: []
 project_pre_build_commands: []
 project_post_build_commands: []
 

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -22,8 +22,14 @@
   file: path="{{ deploy_helper.new_release_path }}/{{ item }}" state=absent
   with_items: project_unwanted_items
 
+- name: Run pre_build_commands_local on Ansible host
+  local_action: "command {{ item.cmd }}"
+  args:
+    chdir: "{{ item.path }}"
+  with_items: project_pre_build_commands_local
+
 - name: Copy project files
-  copy: src="{{ item.src }}" dest="{{ deploy_helper.new_release_path }}/{{ item.dest }}" mode="{{ item.mode | default('0644') }}"
+  synchronize: src="{{ item.src }}" dest="{{ deploy_helper.new_release_path }}/{{ item.dest }}"
   with_items: project_files
 
 - name: Copy project templates


### PR DESCRIPTION
Adds option for local build commands like compiling theme assets. For #95

**Does not run local build commands by default.** I felt like running build commands on the user's local assets should be opt-in, so I couldn't get myself to define `project_pre_build_commands_local` by default. But it seems likely people will want it, so for convenience, I put an example (commented-out) definition in `deploy.yml`. I can remove that if you want, because I also put an example definition in comments in `roles/deploy/defaults/main.yml`. Or, maybe it should be defined in `wordpress_sites`, if theme paths will differ between sites.

**Does copy up dist directory by default.** Adds a definition of `project_files` to `deploy.yml`, making it the default to copy up the theme's`dist` directory. Maybe you'd prefer this definition of `project_files` to be 
- commented out, but still in `deploy.yml`, or
- just an example in comments in `roles/deploy/defaults/main.yml`, or
- defined in `wordpress_sites` if theme paths will differ between sites.

**Switched from copy to synchronize module.** I changed the "Copy project files" task to use the [synchronize](http://docs.ansible.com/synchronize_module.html) module which allows use of a `.rsync-filter` file (like in this [comment](https://github.com/roots/bedrock-ansible/pull/95#issuecomment-86280712) - item 3). Although users wouldn't likely need/use the `.rsync-filter` when copying up a theme's compiled `dist` directory, it could come in handy for other files. However, the synchronize module requires rsync be installed on local and remote. Foresee that being a problem?