### PR TITLE
Fix changing of root password in mariadb task

### DIFF
--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -17,6 +17,7 @@
 
 - name: Set root user password
   mysql_user: name=root
+              host="{{ item }}"
               password="{{ mysql_root_password }}"
               check_implicit_admin=yes
               login_user="{{ mysql_user }}"


### PR DESCRIPTION
Host was left out resulting in some root logins with no password.