### PR TITLE
Add logrotate for WordPress sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bedrock-ansible will configure a server with the following and more:
 
 ## Requirements
 
-* Ansible >= 1.6 - [Installation docs](http://docs.ansible.com/intro_installation.html)
+* Ansible >= 1.8 - [Installation docs](http://docs.ansible.com/intro_installation.html)
 * Virtualbox >= 4.3.10 - [Downloads](https://www.virtualbox.org/wiki/Downloads)
 * Vagrant >= 1.5.4 - [Downloads](http://www.vagrantup.com/downloads.html)
 * Vagrant-bindfs >= 0.3.1 - [Docs](https://github.com/gael-ian/vagrant-bindfs) (Windows users may skip this)

--- a/dev.yml
+++ b/dev.yml
@@ -14,6 +14,7 @@
     - { role: php, when: not hhvm, tags: [php] }
     - { role: hhvm, when: hhvm, tags: [hhvm] }
     - { role: nginx, tags: [nginx] }
+    - { role: logrotate, tags: [logrotate] }
     - { role: memcached, tags: [memcached] }
     - { role: composer, tags: [composer] }
     - { role: wp-cli, tags: [wp-cli] }

--- a/group_vars/all
+++ b/group_vars/all
@@ -30,3 +30,23 @@ ferm_input_list:
     seconds: 300
     hits: 20
     disabled: false
+
+logrotate_scripts:
+  - name: wordpress-sites
+    path: "{{ www_root }}/**/logs/*.log"
+    options:
+      - weekly
+      - maxsize 50M
+      - missingok
+      - rotate 8
+      - compress
+      - delaycompress
+      - notifempty
+      - create 0640 {{ web_user }} {{ web_group }}
+      - sharedscripts
+    scripts:
+      prerotate: |
+        if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+              run-parts /etc/logrotate.d/httpd-prerotate; \
+            fi \
+      postrotate: invoke-rc.d nginx rotate >/dev/null 2>&1

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,5 @@
 - src: f500.project_deploy_module
 - name: ntp
   src: resmo.ntp
+- name: logrotate
+  src: nickhammond.logrotate

--- a/server.yml
+++ b/server.yml
@@ -14,6 +14,7 @@
     - { role: php, when: not hhvm, tags: [php] }
     - { role: hhvm, when: hhvm, tags: [hhvm] }
     - { role: nginx, tags: [nginx] }
+    - { role: logrotate, tags: [logrotate] }
     - { role: memcached, tags: [memcached] }
     - { role: composer, tags: [composer] }
     - { role: wp-cli, tags: [wp-cli] }


### PR DESCRIPTION
Closes #141 

Rotates logs weekly (or sooner if a log reaches 50MB). Keeps 8 rounds of backlogs (compressed) and deletes the rest. Users can customize these options in `group_vars/all`. Not all logs have to use these options. Just add another item to `logrotate_scripts`.

I bumped the Ansible requirement to 1.8 in the README, as necessary for the `.yml` extension on the `requirements.yml` file. In testing, `ansible-galaxy install` does indeed fail before 1.8. 

Notes on the [nickhammond.logrotate](https://github.com/nickhammond/ansible-logrotate) role 
- has a [PR](https://github.com/nickhammond/ansible-logrotate/pull/6) to add `# {{ ansible_managed }}` to the log header.
- puts the matching pattern [in quotes](https://github.com/nickhammond/ansible-logrotate/blob/9c3bb9ecb8207bf6f890764f5cbd139813bdc253/templates/logrotate.d.j2#L1). I would've preferred without. However, quotes [are acceptable](http://manpages.ubuntu.com/manpages/trusty/en/man8/logrotate.8.html), and still worked as I tested.
- BSD license

Some helpful logrotate articles: [slicehost](http://articles.slicehost.com/2010/6/30/understanding-logrotate-on-ubuntu-part-1), [serversforhackers](https://serversforhackers.com/managing-logs-with-logrotate)