### PR TITLE
SSL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* SSL support
 * WP subdomain multisite support
 * Add xdebug role
 * Add logrotate role

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ bedrock-ansible will configure a server with the following and more:
 * WP-CLI
 * Fail2ban
 * ferm
+* SSL support
 
 ## Requirements
 
@@ -69,7 +70,7 @@ For remote servers you'll need to have a base Ubuntu 14.04 server already create
 1. Run `./deploy.sh <environment> <site name>`
 2. To rollback a deploy, run `ansible-playbook -i hosts/<environment> rollback.yml --extra-vars="site=<site name>"`
 
-## Options
+## Configuration
 
 ### HHVM
 
@@ -81,6 +82,10 @@ In the environment files inside the `group_vars` directory, `wordpress_sites` is
 
 * `site_hosts` - hosts that Nginx will listen on
 * `local_path` - path targeting Bedrock-based site directory
+* `ssl` - enable SSL and set paths
+  * `enabled` - `true` or `false` (defaults to `false`)
+  * `key` - local relative path to private key
+  * `cert` - local relative path to certificate
 * `env` - environment variables
   * `wp_home` - `WP_HOME` constant
   * `wp_siteurl` - `WP_SITEURL` constant
@@ -110,10 +115,14 @@ Additional options:
 
 Outgoing mail is done by the sSMTP role. Configure SMTP credentials in `group_vars/all`.
 
+## SSL
+
+Full SSL support is available for your WordPress sites. Note that this will configure your site to be HTTPS **only** by default.
+
+Our HTTPS implementation has all the best practices for performance and security.
+
+Read the Wiki section on [SSL](https://github.com/roots/bedrock-ansible/wiki/SSL) for more documentation.
+
 ## Security
 
 The `secure-root.yml` playbook is provided to help secure your remote servers including better SSH security. See the Wiki for [Locking down root](https://github.com/roots/bedrock-ansible/wiki/Security#locking-down-root).
-
-## Additional documentation
-
-See the [bedrock-ansible Wiki](https://github.com/roots/bedrock-ansible/wiki).

--- a/group_vars/development
+++ b/group_vars/development
@@ -13,10 +13,10 @@ wordpress_sites:
     admin_user: admin
     admin_password: admin
     admin_email: admin@example.dev
-    system_cron: true
     multisite:
       enabled: false
       subdomains: false
+    system_cron: true
     env:
       wp_home: http://example.dev
       wp_siteurl: http://example.dev/wp

--- a/group_vars/production
+++ b/group_vars/production
@@ -6,10 +6,12 @@ wordpress_sites:
       - example.com
     local_path: '../example.com' # path targeting local Bedrock project directory (relative to Ansible root)
     repo: git@github.com:roots/bedrock.git
-    system_cron: true
     multisite:
       enabled: false
       subdomains: false
+    ssl:
+     enabled: false
+    system_cron: true
     env:
       wp_home: http://example.com
       wp_siteurl: http://example.com/wp

--- a/group_vars/staging
+++ b/group_vars/staging
@@ -6,10 +6,12 @@ wordpress_sites:
       - staging.example.com
     local_path: '../example.com' # path targeting local Bedrock project directory (relative to Ansible root)
     repo: git@github.com:roots/bedrock.git
-    system_cron: true
     multisite:
       enabled: false
       subdomains: false
+    ssl:
+     enabled: false
+    system_cron: true
     env:
       wp_home: http://staging.example.com
       wp_siteurl: http://staging.example.com/wp

--- a/roles/nginx/files/ssl-stapling.conf
+++ b/roles/nginx/files/ssl-stapling.conf
@@ -1,0 +1,5 @@
+ssl_stapling on;
+ssl_stapling_verify on;
+
+resolver 8.8.8.8 8.8.4.4 216.146.35.35 216.146.36.36 valid=60s;
+resolver_timeout 2s;

--- a/roles/nginx/files/ssl.conf
+++ b/roles/nginx/files/ssl.conf
@@ -1,0 +1,34 @@
+# Protect against the BEAST and POODLE attacks by not using SSLv3 at all. If you need to support older browsers (IE6) you may need to add
+# SSLv3 to the list of protocols below.
+ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+# Ciphers set to best allow protection from Beast, while providing forwarding secrecy, as defined by Mozilla (Intermediate Set) - https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx
+ssl_ciphers                ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
+ssl_prefer_server_ciphers  on;
+
+# Optimize SSL by caching session parameters for 10 minutes. This cuts down on the number of expensive SSL handshakes.
+# The handshake is the most CPU-intensive operation, and by default it is re-negotiated on every new/parallel connection.
+# By enabling a cache (of type "shared between all Nginx workers"), we tell the client to re-use the already negotiated state.
+# Further optimization can be achieved by raising keepalive_timeout, but that shouldn't be done unless you serve primarily HTTPS.
+ssl_session_cache    shared:SSL:10m; # a 1mb cache can hold about 4000 sessions, so we can hold 40000 sessions
+ssl_session_timeout  24h;
+
+# SSL buffer size was added in 1.5.9
+ssl_buffer_size 1400; # 1400 bytes to fit in one MTU
+
+# Session tickets appeared in version 1.5.9
+#
+# nginx does not auto-rotate session ticket keys: only a HUP / restart will do so and
+# when a restart is performed the previous key is lost, which resets all previous
+# sessions. The fix for this is to setup a manual rotation mechanism:
+# http://trac.nginx.org/nginx/changeset/1356a3b9692441e163b4e78be4e9f5a46c7479e9/nginx
+#
+# Note that you'll have to define and rotate the keys securely by yourself. In absence
+# of such infrastructure, consider turning off session tickets:
+ssl_session_tickets off;
+
+# Use a higher keepalive timeout to reduce the need for repeated handshakes
+keepalive_timeout 300; # up from 75 secs default
+spdy_keepalive_timeout 300;
+
+spdy_headers_comp 6;

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -17,6 +17,10 @@
     - mime.types
     - h5bp/
 
+- name: Copy SSL conf files
+  copy: src="{{ item }}" dest=/etc/nginx/{{ item | basename }} mode=644
+  with_fileglob: '*'
+
 - name: Create nginx.conf
   template: src=nginx.conf.j2 dest=/etc/nginx/nginx.conf
   notify: reload nginx

--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -1,4 +1,17 @@
 ---
+- name: Create SSL directory
+  file: dest=/etc/nginx/ssl state=directory
+
+- name: Copy SSL cert
+  copy: src="{{ item.value.ssl.cert }}" dest=/etc/nginx/ssl/{{ item.value.ssl.cert | basename }} mode=0640
+  with_dict: wordpress_sites
+  when: item.value.ssl.enabled | default(False)
+
+- name: Copy SSL key
+  copy: src="{{ item.value.ssl.key }}" dest=/etc/nginx/ssl/{{ item.value.ssl.key | basename }} mode=0600
+  with_dict: wordpress_sites
+  when: item.value.ssl.enabled | default(False)
+
 - name: Create WordPress configuration for Nginx
   template: src="wordpress-site.conf.j2"
             dest="/etc/nginx/sites-available/{{ item.key }}.conf"

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -1,7 +1,12 @@
 # {{ ansible_managed }}
 
 server {
-  listen *:80;
+  {% if item.value.ssl | default(false) %}
+  listen 443 ssl spdy;
+  {% else %}
+  listen 80;
+  {% endif %}
+
   server_name  {{ item.value.site_hosts | join(' ') }};
   access_log   {{ www_root }}/{{ item.key }}/logs/{{ item.key }}.access.log;
   error_log    {{ www_root }}/{{ item.key }}/logs/{{ item.key }}.error.log;
@@ -12,8 +17,8 @@ server {
   charset utf-8;
 
   {% if item.value.env.wp_env == 'development' -%}
-    # See Virtualbox section at http://wiki.nginx.org/Pitfalls
-    sendfile off;
+  # See Virtualbox section at http://wiki.nginx.org/Pitfalls
+  sendfile off;
   {%- endif %}
 
   {% if item.value.multisite | default(false) %}
@@ -25,13 +30,26 @@ server {
     {%- endif %}
   {%- endif %}
 
+  {% if item.value.ssl | default(false) %}
+  include ssl.conf;
+  include ssl-stapling.conf;
+
+  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
+  add_header X-Frame-Options SAMEORIGIN;
+
+  ssl_certificate         /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};
+  ssl_trusted_certificate /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};
+  ssl_certificate_key     /etc/nginx/ssl/{{ item.value.ssl.key | basename }};
+  {% endif %}
+
   include wordpress.conf;
 }
 
-{% for host in item.value.site_hosts if strip_www %}
+{% for host in item.value.site_hosts if item.value.ssl | default(False) %}
 server {
-  listen *:80;
-  server_name www.{{ host }};
-  return 301 $scheme://{{ host }}$request_uri;
+  listen 80;
+  server_name {{ host }} www.{{ host }};
+  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
+  return 301 https://{{ host }}$request_uri;
 }
 {% endfor %}


### PR DESCRIPTION
Enable SSL on a per site basis. Certificate and key files are referenced locally and copied to the remote server.

Closes #38 

Lot of credit goes to: @nathanielks, @enricodeleo, @rstormsf

/cc @fullyint 

Todo:
- [x] Clean up config files
- [x] README/doc updates