### PR TITLE
Set ansible roles_path relative to ansible directory in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,9 @@ require 'yaml'
 
 ANSIBLE_PATH = '.' # path targeting Ansible directory (relative to Vagrantfile)
 
+# Set Ansible roles_path relative to Ansible directory
+ENV['ANSIBLE_ROLES_PATH'] = File.join(ANSIBLE_PATH, 'vendor', 'roles')
+
 config_file = File.join(ANSIBLE_PATH, 'group_vars/development')
 
 if File.exists?(config_file)


### PR DESCRIPTION
Ansible can't find the galaxy roles in vendor/roles after moving the Vagrantfile to a project directory per [wiki instructinons](https://github.com/roots/bedrock-ansible/wiki/Vagrantfile).

ansible.cfg isn't loaded and roles_path would be relative to current directory anyway.

So instead, set roles_path in Vagrantfile relative to ANSIBLE_PATH with ANSIBLE_ROLES_PATH environment variable.