### PR TITLE
Deploy Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You should now have the following directories at the same level somewhere:
 
 ```
 project/                - Primary folder for the project
-├── bedrock-ansible/    - This repo
+├── bedrock-ansible/    - Your version of this repo
 └── example.com/        - A Bedrock-based site
 ```
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,7 +16,7 @@ Available environments:
 `( IFS=$'\n'; echo "${ENVIRONMENTS[*]}" )`
 
 Examples:
-  deploy staging example.dev
+  deploy staging example.com
   deploy production example.com
 "
 }

--- a/deploy.yml
+++ b/deploy.yml
@@ -6,15 +6,6 @@
   vars:
     project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"
-    project_git_repo: "{{ project.repo }}"
-    project_version: "{{ branch | default('master') }}"
-    project_templates:
-      - name: .env config
-        src: roles/deploy/templates/env.j2
-        dest: .env
-    project_shared_children:
-      - path: /web/app/uploads
-        src: uploads
 
   roles:
     - deploy

--- a/group_vars/all
+++ b/group_vars/all
@@ -5,8 +5,8 @@ mysql_user: root
 www_root: /srv/www
 
 mail_smtp_server: smtp.mandrillapp.com:587
-mail_admin: admin@example.dev
-mail_hostname: example.dev
+mail_admin: admin@example.com
+mail_hostname: example.com
 mail_user: smtp_user
 mail_password: smtp_password
 

--- a/group_vars/development
+++ b/group_vars/development
@@ -3,10 +3,11 @@ mysql_root_password: devpw
 web_user: vagrant
 
 wordpress_sites:
-  example.dev:
+  example.com:
     site_hosts:
       - example.dev
-    local_path: '../example.dev' # path targeting local project directory (relative to root/Vagrantfile)
+    local_path: '../example.com' # path targeting local Bedrock project directory (relative to Ansible root)
+    repo: git@github.com:roots/bedrock.git
     site_install: true
     site_title: Example Site
     admin_user: admin
@@ -23,7 +24,6 @@ wordpress_sites:
       db_name: example_dev
       db_user: example_dbuser
       db_password: example_dbpassword
-      domain_current_site: example.dev # required for multisite
 
 php_error_reporting: 'E_ALL'
 php_display_errors: 'On'

--- a/group_vars/production
+++ b/group_vars/production
@@ -5,6 +5,7 @@ wordpress_sites:
     site_hosts:
       - example.com
       - 192.168.50.5
+    local_path: '../example.com' # path targeting local Bedrock project directory (relative to Ansible root)
     repo: git@github.com:roots/bedrock.git
     system_cron: true
     multisite:
@@ -17,7 +18,6 @@ wordpress_sites:
       db_name: example_prod
       db_user: example_dbuser
       db_password: example_dbpassword
-      domain_current_site: example.dev # required for multisite
       auth_key: "generateme"
       auth_salt: "generateme"
       logged_in_key: "generateme"

--- a/group_vars/staging
+++ b/group_vars/staging
@@ -1,10 +1,11 @@
 mysql_root_password: stagingpw
 
 wordpress_sites:
-  staging.example.com:
+  example.com:
     site_hosts:
       - staging.example.com
       - 192.168.50.5
+    local_path: '../example.com' # path targeting local Bedrock project directory (relative to Ansible root)
     repo: git@github.com:roots/bedrock.git
     system_cron: true
     multisite:
@@ -17,7 +18,6 @@ wordpress_sites:
       db_name: example_staging
       db_user: example_dbuser
       db_password: example_dbpassword
-      domain_current_site: example.dev # required for multisite
       auth_key: "generateme"
       auth_salt: "generateme"
       logged_in_key: "generateme"

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -1,12 +1,8 @@
-# These variables must be set
-# project_root: "path_to_project_on_the_target_machine"
-# project_deploy_strategy: "git" or "synchronize"
-
 # If you use the "git" strategy:
 # - you must set a repository (no default)
-# project_git_repo: "git_repository"
+project_git_repo: "{{ project.repo }}"
 # - you can set the git ref to deploy (can be a branch, tag or commit hash)
-project_version: "master"
+project_version: "{{ branch | default('master') }}"
 
 # If you use the "rsync" strategy:
 # - you can set a timeout for the synchonize module
@@ -20,49 +16,50 @@ project_deploy_synchronize_delete: false
 project_source_path: "{{ project_root }}/shared/source"
 
 # Files or folders to remove from the source when deploying
-project_unwanted_items: [ '.git' ]
+project_unwanted_items: ['.git']
 
-project_has_composer: true
-
-# Default values to run composer install
-project_composer_binary: composer
-project_command_for_composer_install: "{{ project_composer_binary }} install --no-ansi --no-dev --no-interaction --no-progress --optimize-autoloader --no-scripts"
-# When set to true the old vendor dir is copied to the new release to speed up composer install
-project_copy_previous_composer_vendors: false
-project_composer_vendor_path: vendor
+# There are certain folders you'll want to copy from release to release to speed up deploys.
+# Examples: Composer's `vendor` folder, npm's `node_modules`.
+# These should not be part of project_shared_children since dependencies need to be atomic and tied to a deploy.
+project_copy_folders:
+  - vendor
 
 # All the files to copy to the remote system on deploy. These could contain config files.
 # Example:
-# project_files:
+# project_local_files:
 #   - name: "some_file"           // <- optional, for your own reference and readability
 #     src: "local-path-to-file"   // <- relative or absolute, just like Ansible
 #     dest: "remote-path-to-file"
 #   - name: compiled theme assets
-#     src: ../example.dev/web/app/themes/sage/dist
+#     src: "{{ project.local_path }}/web/app/themes/sage/dist"
 #     dest: web/app/themes/sage
-project_files: []
+project_local_files: []
 
-# All the templates to copy to the remote system on deploy. These could contain config files.
-# Works the same as the project_files
-project_templates: []
+# All the templates to process on the remote system on deploy. These could contain config files.
+# `src` and `dest` paths work the same as project_local_files.
+project_templates:
+  - name: .env config
+    src: roles/deploy/templates/env.j2
+    dest: .env
 
 # The shared_children is a list of all files/folders in your project that need to be linked to a path in "/shared".
-# For example a sessions directory or an uploads folder.. They are created if they don't exist, with the type
-# specified in the "type" key (file or directory).
+# For example a sessions directory or an uploads folder. They are created if they don't exist, with the type
+# specified in the `type` key (file or directory).
 # Example:
 # project_shared_children:
 #   - path: "/app/sessions"
 #     src: "sessions"
 #     type: "file" / "directory"  // <- optional, defaults to "directory"
-#   - path: "/web/uploads"
-#     src: "uploads"
-project_shared_children: []
+project_shared_children:
+  - path: /web/app/uploads
+    src: uploads
 
 # The project_environment is a list of environment variables added to the various *_commands
 # Example:
 # project_environment:
 #   WP_ENV: "production"
-project_environment: {}
+project_environment:
+  WP_ENV: "{{ project.env.wp_env }}"
 
 # There are a few moments in this role where arbitrary command(s) can be run. These commands receive
 # the "project_environment" so deploys for different stages can be done by changing this.
@@ -71,7 +68,7 @@ project_environment: {}
 # `new_release_path` on the remote server (for `project_pre_build_commands` and `project_post_build_commands`).
 # Examples:
 # project_pre_build_commands_local:
-#   - path: ../example.dev/web/app/themes/sage
+#   - path: "{{ project.local_path }}/web/app/themes/sage"
 #     cmd: gulp --production
 # project_post_build_commands:
 #   - path: web/app/themes/mytheme
@@ -79,7 +76,13 @@ project_environment: {}
 #   - cmd: wp db import posts.sql
 project_pre_build_commands_local: []
 project_pre_build_commands: []
-project_post_build_commands: []
+project_post_build_commands:
+  - cmd: "composer install --no-ansi --no-dev --no-interaction --no-progress --optimize-autoloader --no-scripts"
+
+# Post finalize commands are run with Ansible's `shell` module.
+# These are meant primarily for service restarts such as php5-fpm or memcached.
+project_post_finalize_commands:
+  - sudo service php5-fpm reload
 
 # At the end of the role, the unfinished_filename is removed and the "current" symlink is set to
 # the release. If you need to perform your own actions before this happens, set "project_finalize"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -7,6 +7,7 @@
        dest="{{ project_source_path }}"
        version="{{ project_version }}"
        accept_hostkey=yes
+  register: git_commit
 
 - name: write unfinished file
   file: path="{{ project_source_path }}/{{ deploy_helper.unfinished_filename }}" state=touch
@@ -14,7 +15,7 @@
 - name: Copy files to new build dir
   command: cp -pr {{ project_source_path }} {{ deploy_helper.new_release_path }}
 
-- name: Move site into root
+- name: Move project subtree into root folder
   shell: mv {{ deploy_helper.new_release_path }}/{{ project_subtree }}/* {{ deploy_helper.new_release_path }}
   when: project_subtree is defined
 
@@ -28,9 +29,9 @@
     chdir: "{{ item.path }}"
   with_items: project_pre_build_commands_local
 
-- name: Copy project files
+- name: Copy project local files
   synchronize: src="{{ item.src }}" dest="{{ deploy_helper.new_release_path }}/{{ item.dest }}"
-  with_items: project_files
+  with_items: project_local_files
 
 - name: Copy project templates
   template: src="{{ item.src }}" dest="{{ deploy_helper.new_release_path }}/{{ item.dest }}" mode="{{ item.mode | default('0644') }}"
@@ -43,21 +44,15 @@
   with_items: project_pre_build_commands
   environment: project_environment
 
-- name: Check if vendor dir exists
-  stat: path="{{ deploy_helper.current_path }}/{{ project_composer_vendor_path }}"
-  register: check_composer_vendor_path
-  when: project_copy_previous_composer_vendors | default(True)
+- name: Check if project folders exist
+  stat: path="{{ deploy_helper.current_path }}/{{ item }}"
+  register: project_folder_paths
+  with_items: project_copy_folders
 
-- name: Copy vendor dir if exists to speed up composer
-  command: cp -rp {{ deploy_helper.current_path }}/{{ project_composer_vendor_path }} {{ deploy_helper.new_release_path }}/{{ project_composer_vendor_path }}
-  when: project_copy_previous_composer_vendors and check_composer_vendor_path.stat.exists
-
-- name: Do composer install
-  command: "{{ project_command_for_composer_install }}"
-  args:
-    chdir: "{{ deploy_helper.new_release_path }}"
-  environment: project_environment
-  when: project_has_composer
+- name: Copy project folders
+  command: cp -rp {{ deploy_helper.current_path }}/{{ item.item }} {{ deploy_helper.new_release_path }}/{{ item.item }}
+  with_items: project_folder_paths.results
+  when: item.stat.exists == True
 
 - name: Ensure shared sources are present
   file: path="{{ deploy_helper.shared_path }}/{{ item.src }}" state="{{ item.type | default('directory') }}"
@@ -82,5 +77,11 @@
   deploy_helper: path="{{ project_root }}" release="{{ deploy_helper.new_release }}" state=finalize
   when: project_finalize
 
-- name: Reload php-fpm
-  shell: sudo service php5-fpm reload
+- name: Run post_finalize_commands
+  shell: "{{ item }}"
+  args:
+    chdir: "{{ deploy_helper.new_release_path }}"
+  with_items: project_post_finalize_commands
+
+- debug:
+    msg: "{{ project_version }}@{{ git_commit.after | truncate(7, True, '') }} deployed as release {{ deploy_helper.new_release }}"


### PR DESCRIPTION
* Use `local_path` for easier `pre_build_commands_local` paths
* Create `project_copy_folders` as a generic method of copying folders
  between releases
* Move copying Composer's `vendor` dir into `project_copy_folders`
* Rename `project_files` to `project_local_files`
* Remove Composer specific commands
* Add Composer install to `project_post_build_commands`
* Auto set project_environment with `WP_ENV`
* Add `project_post_finalize_commands`

/cc @fullyint @retlehs 