### PR TITLE
Specify Virtualbox as provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# Specify Vagrant provider as Virtualbox
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
 require 'yaml'
 
 ANSIBLE_PATH = '.' # path targeting Ansible directory (relative to Vagrantfile)


### PR DESCRIPTION
To be consistent with Roots Example Project. `vagrant up` fails otherwise because of the `mv ansible/Vagrantfile .` step.