### PR TITLE
Don't set HSTS header over HTTP

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -49,7 +49,6 @@ server {
 server {
   listen 80;
   server_name {{ host }} www.{{ host }};
-  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
   return 301 https://{{ host }}$request_uri;
 }
 {% endfor %}


### PR DESCRIPTION
This could lead to an MITM attack to modify the header over HTTP.

According to spec:

> An HSTS Host MUST NOT include the STS header field in HTTP responses
conveyed over non-secure transport.