### PR TITLE
Windows compatibility

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,16 +52,23 @@ Vagrant.configure('2') do |config|
     end
   end
 
-  config.vm.provision :ansible do |ansible|
-    ansible.playbook = File.join(ANSIBLE_PATH, 'dev.yml')
-    ansible.groups = {
-      'web' => ['default'],
-      'development' => ['default']
-    }
+  if Vagrant::Util::Platform.windows?
+    config.vm.provision :shell do |sh|
+      sh.path = File.join(ANSIBLE_PATH, 'windows.sh')
+      sh.args = ANSIBLE_PATH
+    end
+  else
+    config.vm.provision :ansible do |ansible|
+      ansible.playbook = File.join(ANSIBLE_PATH, 'dev.yml')
+      ansible.groups = {
+        'web' => ['default'],
+        'development' => ['default']
+      }
 
-    if vars = ENV['ANSIBLE_VARS']
-      extra_vars = Hash[vars.split(',').map { |pair| pair.split('=') }]
-      ansible.extra_vars = extra_vars
+      if vars = ENV['ANSIBLE_VARS']
+        extra_vars = Hash[vars.split(',').map { |pair| pair.split('=') }]
+        ansible.extra_vars = extra_vars
+      end
     end
   end
 

--- a/hosts/development
+++ b/hosts/development
@@ -1,6 +1,6 @@
 # Not used. Vagrant generates its own hosts file automatically and uses it
 [web]
-vagrant ansible_ssh_host=127.0.0.1 ansible_ssh_port=2200 ansible_ssh_private_key_file='~/.vagrant.d/insecure_private_key'
+127.0.0.1
 
 [development:children]
 web

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -3,9 +3,13 @@
 
 - name: Create .env file
   template: src="env.j2"
-            dest="{{ www_root }}/{{ item.key }}/current/.env"
+            dest="/tmp/.env.temp"
             owner="{{ web_user }}"
             group="{{ web_group }}"
+  with_dict: wordpress_sites
+
+- name: Move .env file
+  command: mv /tmp/.env.temp {{ www_root }}/{{ item.key }}/current/.env
   with_dict: wordpress_sites
 
 - name: Install Dependencies with Composer

--- a/windows.sh
+++ b/windows.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Windows provisioner for bedrock-ansible
+# heavily modified and based on KSid/windows-vagrant-ansible
+# @author Andrea Brandi
+# @version 1.0
+
+ANSIBLE_PATH=$1
+TEMP_HOSTS="/tmp/ansible_hosts"
+
+# Create an ssh key if not already created.
+if [ ! -f ~/.ssh/id_rsa ]; then
+  echo -e "\n\n\n" | ssh-keygen -t rsa
+fi
+
+# Install Ansible and its dependencies if not installed.
+if [ ! -f /usr/bin/ansible ]; then
+  echo "Adding Ansible repository..."
+  sudo apt-add-repository ppa:ansible/ansible
+  echo "Updating system..."
+  sudo apt-get -y update
+  echo "Installing Ansible..."
+  sudo apt-get -y install ansible
+fi
+
+if [ ! -d /vagrant/${ANSIBLE_PATH}/vendor ]; then
+  echo "Running Ansible Galaxy install"
+  ansible-galaxy install -r /vagrant/${ANSIBLE_PATH}/requirements.yml -p /vagrant/${ANSIBLE_PATH}/vendor/roles
+fi
+
+if [ -d ${TEMP_HOSTS} ]; then
+  echo "Cleaning old Ansible Hosts"
+  rm -rf ${TEMP_HOSTS}
+fi
+
+cp -R /vagrant/${ANSIBLE_PATH}/hosts ${TEMP_HOSTS} && chmod -x ${TEMP_HOSTS}/*
+echo "Running Ansible Playbooks"
+cd /vagrant/${ANSIBLE_PATH}/
+ansible-playbook /vagrant/${ANSIBLE_PATH}/dev.yml -i ${TEMP_HOSTS}/development --sudo --user=vagrant --connection=local
+rm -rf ${TEMP_HOSTS}


### PR DESCRIPTION
This is getting the ball rolling on Windows compatibility.

I've incorporated the info in the wiki and fixed the shell script so that Ansible runs on the VM, the `ansible-galaxy` files get loaded correctly, and Ansible provisions the VM.

I've hit one snag where the [start php5-fpm service](https://github.com/roots/bedrock-ansible/blob/master/roles/php/tasks/main.yml#L20-21) errors, but the verbose output is basically useless. I'll need either some more Ansible or Windows experts to take a look.

Issues:
- [x] Ansible erroring on php5-fpm start: https://github.com/ansible/ansible/issues/10675
  - possible fix to use Ansible 1.9.0.1
- [x] Pass `windows.sh` the ansible directory in the vagrant box. Otherwise if the project places `bedrock-ansible` in a sub-directory, all calls to `/vagrant` need to be updated as well.
- [x] Decide how Windows users should be able to deploy. I can think of two options:
  - SSH in and run the same script everyone else does
  - since the `windows.sh` script is basically ready to go, they could potentially do something like `deploy=‘production' vagrant up`