### PR TITLE
Remove possibly confusing default option

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -29,7 +29,6 @@ ferm_input_list:
     dport: [ssh]
     seconds: 300
     hits: 20
-    disabled: false
 
 logrotate_scripts:
   - name: wordpress-sites


### PR DESCRIPTION
`ferm_input_list` rule `disabled` default to false. including this in the `all` file might be confusing for the user, since the `ssh` rule (the case where the `disabled: false` was included) is one of the more important rule. if the user change it to `disabled: true`, they most likely will lock themselves out of their instance.