### PR TITLE
`server_name` in SSL and non-SSL blocks should mirror each other 

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -45,10 +45,10 @@ server {
   include wordpress.conf;
 }
 
-{% for host in item.value.site_hosts if item.value.ssl is defined and item.value.ssl.enabled | default(False) %}
+{% if item.value.ssl is defined and item.value.ssl.enabled | default(False) %}
 server {
   listen 80;
-  server_name {{ host }} www.{{ host }};
-  return 301 https://{{ host }}$request_uri;
+  server_name {{ item.value.site_hosts | join(' ') }};
+  return 301 https://$host$request_uri;
 }
-{% endfor %}
+{% endif %}


### PR DESCRIPTION
In `roles/wordpress-setup/templates/wordpress-site.conf.j2`:

When TLS is enabled, the non-TLS server block adds `www.` to every item in `site_hosts`, whether you want it or not. This can lead to disparity between TLS and non-TLS server blocks, and makes using wildcard `site_hosts` impossible (e.g., `*.example.com`).