### PR TITLE
Update wordpress-site.conf.j2

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 server {
-  {% if item.value.ssl.enabled | default(false) %}
+  {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) %}
   listen 443 ssl spdy;
   {% else %}
   listen 80;
@@ -30,7 +30,7 @@ server {
     {%- endif %}
   {%- endif %}
 
-  {% if item.value.ssl.enabled | default(false) %}
+  {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) %}
   include ssl.conf;
   include ssl-stapling.conf;
 
@@ -45,7 +45,7 @@ server {
   include wordpress.conf;
 }
 
-{% for host in item.value.site_hosts if item.value.ssl.enabled | default(False) %}
+{% for host in item.value.site_hosts if item.value.ssl is defined and item.value.ssl.enabled | default(False) %}
 server {
   listen 80;
   server_name {{ host }} www.{{ host }};


### PR DESCRIPTION
In the event that item.value.ssl isn't defined, let's go ahead and check to see if it exists and if so, continue. This prevents errors when it's not defined, preventing the play from proceeding.