### PR TITLE
Add swapfile role

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -5,3 +5,5 @@
   src: nickhammond.logrotate
 - name: php5-xdebug
   src: MaximeThoonsen.php5-xdebug
+- name: swapfile
+  src: kamaln7.swapfile

--- a/server.yml
+++ b/server.yml
@@ -5,6 +5,7 @@
 
   roles:
     - { role: common, tags: [common] }
+    - { role: swapfile, swapfile_size: 1GB, tags: [swapfile] }
     - { role: fail2ban, tags: [fail2ban] }
     - { role: ferm, tags: [ferm] }
     - { role: ntp }


### PR DESCRIPTION
This came up before in https://github.com/roots/bedrock-ansible/pull/152 but now it's using an existing Galaxy role.

Going with 1GB swap as default. This is important because by default Digital Ocean server's don't have a swap file and the 512MB droplet is likely to need one.