### PR TITLE
Fix conditional check for subtree in deploy

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Move project subtree into root folder
   shell: mv {{ deploy_helper.new_release_path }}/{{ project_subtree }}/* {{ deploy_helper.new_release_path }}
-  when: project_subtree
+  when: project_subtree is defined
 
 - name: Remove unwanted files/folders from new release
   file: path="{{ deploy_helper.new_release_path }}/{{ item }}" state=absent


### PR DESCRIPTION
Fixes "error while evaluating conditional" error when deploying multiple sites one by one.  Ansible needs to check if the variable "is defined" since its not a straight boolean true/false check.