### PR TITLE
Remove mysql_root_password from development config

### DIFF
--- a/group_vars/development
+++ b/group_vars/development
@@ -1,5 +1,3 @@
-mysql_root_password: devpw
-
 web_user: vagrant
 
 wordpress_sites:


### PR DESCRIPTION
As mentioned in #73 , changing this value to anything else in development, will cause the playbook to fail, since the base box MariaDB root password is already set. Removing the option will reduce the likeliness of someone having the error, until a permanent fix can be made.