### PR TITLE
Disable exposing PHP version to the world

### DIFF
--- a/roles/php/templates/php.ini.j2
+++ b/roles/php/templates/php.ini.j2
@@ -13,6 +13,7 @@ sendmail_path = {{ php_sendmail_path }}
 session.save_path = {{ php_session_save_path }}
 track_errors = {{ php_track_errors }}
 upload_max_filesize = {{ php_upload_max_filesize }}
+expose_php = Off
 
 [mysqlnd]
 mysqlnd.collect_memory_statistics = {{ php_mysqlnd_collect_memory_statistics }}


### PR DESCRIPTION
Do not expose PHP version via header, for security reasons.