### PR TITLE
Fastcgi caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Configure complete [Bedrock](https://roots.io/bedrock/)-based WordPress ready se
 bedrock-ansible will configure a server with the following and more:
 
 * Ubuntu 14.04 Trusty LTS
-* Nginx
+* Nginx (with optional FastCGI caching)
 * PHP 5.6 (or [HHVM](http://hhvm.com/))
 * [MariaDB](https://mariadb.org/) as a drop-in MySQL replacement (but better)
 * sSMTP (mail delivery)
@@ -116,6 +116,9 @@ For a complete, working example you can see our [example project](https://github
   * `enabled` - Multisite enabled flag (required, set to `false`)
   * `subdomains` - subdomains option
   * `base_path` - base path/current site path
+* `cache` - hash of cache options
+  * `enabled` - Cache enabled flag (required, set to `false`)
+  * `duration` - Duration of the cache (default: `30s`)
 * `env` - environment variables
   * `wp_home` - `WP_HOME` constant (required)
   * `wp_siteurl` - `WP_SITEURL` constant (required)
@@ -137,6 +140,10 @@ Full SSL support is available for your WordPress sites. Note that this will conf
 Our HTTPS implementation has all the best practices for performance and security.
 
 Read the Wiki section on [SSL](https://github.com/roots/bedrock-ansible/wiki/SSL) for more documentation.
+
+## Caching
+
+You can enable FastCGI caching on a per site basis. The cache is a low duration, "micro-cache" type setup. More info on how to configure the different options can be found in the [FastCGI caching](https://github.com/roots/bedrock-ansible/wiki/FastCGI-caching) wiki page.
 
 ## Security
 

--- a/group_vars/development
+++ b/group_vars/development
@@ -18,6 +18,9 @@ wordpress_sites:
       subdomains: false
     ssl:
       enabled: false
+    cache:
+      enabled: false
+      duration: 30s
     system_cron: true
     env:
       wp_home: http://example.dev

--- a/group_vars/production
+++ b/group_vars/production
@@ -12,6 +12,9 @@ wordpress_sites:
       subdomains: false
     ssl:
       enabled: false
+    cache:
+      enabled: false
+      duration: 30s
     system_cron: true
     env:
       wp_home: http://example.com

--- a/group_vars/staging
+++ b/group_vars/staging
@@ -12,6 +12,9 @@ wordpress_sites:
       subdomains: false
     ssl:
       enabled: false
+    cache:
+      enabled: false
+      duration: 30s
     system_cron: true
     env:
       wp_home: http://staging.example.com

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -2,3 +2,12 @@
 logs_root: /var/log/nginx/
 nginx_user: www-data
 strip_www: true
+
+# Fastcgi cache params
+nginx_cache_path: /var/cache/nginx
+nginx_cache_duration: 30s
+nginx_cache_key_storage_size: 10m
+nginx_cache_size: 250m
+nginx_cache_inactive: 1h
+nginx_skip_cache_uri: /wp-admin/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml
+nginx_skip_cache_cookie: comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Move h5bp configs
   command: creates=/etc/nginx/h5bp/ cp -R /etc/nginx/h5bp-server-configs/h5bp /etc/nginx/h5bp
 
-- name: Copy SSL conf files
+- name: Copy conf files
   copy: src="{{ item }}" dest=/etc/nginx/{{ item | basename }} mode=644
   with_fileglob: '*'
 

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -36,6 +36,15 @@ http {
   # Hide nginx version information.
   server_tokens off;
 
+  # Setup the fastcgi cache.
+  fastcgi_cache_path {{ nginx_cache_path }} levels=1:2 keys_zone=wordpress:{{ nginx_cache_key_storage_size }} max_size={{ nginx_cache_size }} inactive={{ nginx_cache_inactive }};
+  fastcgi_cache_use_stale updating error timeout invalid_header http_500;
+  fastcgi_cache_lock on;
+  fastcgi_cache_key $scheme$host$request_uri$request_method;
+  fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
+  fastcgi_pass_header Set-Cookie;
+  fastcgi_pass_header Cookie;
+
   # Define the MIME types for files.
   include       h5bp-server-configs/mime.types;
   default_type  application/octet-stream;

--- a/roles/nginx/templates/wordpress.conf.j2
+++ b/roles/nginx/templates/wordpress.conf.j2
@@ -4,19 +4,6 @@ location / {
   try_files $uri $uri/ /index.php?$args;
 }
 
-location ~ \.php$ {
-  try_files $uri =404;
-  include fastcgi_params;
-  fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
-  fastcgi_param DOCUMENT_ROOT $realpath_root;
-  {% if hhvm %}
-  fastcgi_pass unix:/var/run/hhvm/hhvm.sock;
-  {% else %}
-  fastcgi_pass unix:/var/run/php5-fpm-wordpress.sock;
-  {% endif %}
-  client_max_body_size 0;
-}
-
 include h5bp/directive-only/x-ua-compatible.conf;
 include h5bp/location/cross-domain-fonts.conf;
 include h5bp/location/protect-system-files.conf;

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -3,7 +3,7 @@
 server {
   {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) %}
   listen 443 ssl spdy;
-  {% else %}
+  {% else -%}
   listen 80;
   {% endif %}
 
@@ -21,11 +21,11 @@ server {
   sendfile off;
   {%- endif %}
 
-  {% if item.value.multisite | default(false) %}
-    {% if item.value.multisite.subdomains | default(false) %}
+  {% if item.value.multisite | default(false) -%}
+    {% if item.value.multisite.subdomains | default(false) -%}
       rewrite ^/(wp-.*.php)$ /wp/$1 last;
       rewrite ^/(wp-(content|admin|includes)/.*) /wp/$1 last;
-    {%- else %}
+    {%- else -%}
       include wordpress_multisite_subdirectories.conf;
     {%- endif %}
   {%- endif %}
@@ -44,6 +44,42 @@ server {
 
   include includes.d/{{ item.key }}/*.conf;
   include wordpress.conf;
+
+  location ~ \.php$ {
+    try_files $uri =404;
+    {% if item.value.cache is defined and item.value.cache.enabled | default(false) -%}
+    add_header Fastcgi-Cache $upstream_cache_status;
+    set $skip_cache 0;
+
+    if ($query_string != "") {
+      set $skip_cache 1;
+    }
+
+    # Don't cache uris containing the following segments
+    if ($request_uri ~* "{{ item.value.cache.skip_cache_uri | default(nginx_skip_cache_uri) }}") {
+      set $skip_cache 1;
+    }
+
+    # Don't use the cache if cookies includes the following
+    if ($http_cookie ~* "{{ item.value.cache.skip_cache_cookie | default(nginx_skip_cache_cookie) }}") {
+      set $skip_cache 1;
+    }
+
+    fastcgi_cache wordpress;
+    fastcgi_cache_valid {{ item.value.cache.duration | default(nginx_cache_duration) }};
+    fastcgi_cache_bypass $skip_cache;
+    fastcgi_no_cache $skip_cache;
+    {% endif -%}
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+    fastcgi_param DOCUMENT_ROOT $realpath_root;
+    {% if hhvm -%}
+    fastcgi_pass unix:/var/run/hhvm/hhvm.sock;
+    {% else -%}
+    fastcgi_pass unix:/var/run/php5-fpm-wordpress.sock;
+    {% endif -%}
+    client_max_body_size 0;
+  }
 }
 
 {% if item.value.ssl is defined and item.value.ssl.enabled | default(False) %}


### PR DESCRIPTION
Hello, as mentioned in #186 this is a "microcaching" setup we have used in the past with Bedrock. 

I have a couple of question about where should I go from now.

* I implemented the cache globally, as in "enabled" or "disabled" for all sites on the server. Should it stays like that or should that be handled for each sites separately?
* I initially toyed with the cache residing in `/var/run` since it is in memory instead of being on the filesystem. However I decided to scrap the idea, because it would require changing the Nginx init script to  create the folder after each server reboot, since `/var/run` is cleared. What do you think?
* Cache size: should this be a fixed size, a size based on the number of sites on the server, or just user configurable?
* Should the cache be enabled by default? (I think it should)
* Should this feature be documented in the Readme or the wiki?

Comments are welcome.

I will be following shortly with another pull request that aim to prevent website DDOS using 404s. That was one of the weak point we saw when using the cache.
