### PR TITLE
Insert full path to service command, add hhvm restart minute

### DIFF
--- a/roles/hhvm/defaults/main.yml
+++ b/roles/hhvm/defaults/main.yml
@@ -1,1 +1,2 @@
 hhvm_daily_restart_hour: 2
+hhvm_daily_restart_minute: 30

--- a/roles/hhvm/tasks/main.yml
+++ b/roles/hhvm/tasks/main.yml
@@ -36,7 +36,8 @@
 - name: Create cron job to restart HHVM service daily
   cron: name="Restart HHVM daily"
         hour="{{ hhvm_daily_restart_hour }}"
-        job="service hhvm restart"
+        minute="{{ hhvm_daily_restart_minute }}"
+        job="/usr/sbin/service hhvm restart >/dev/null >2&1"
         user=root
         cron_file=hhvm-daily-restart
   when: hhvm_daily_restart | default(True)


### PR DESCRIPTION
This ensures that HHVM is restarted just once and not every minute between 2 and 3am. Also provides for full path to the service command.