### PR TITLE
Add trailing slash to WP core rewrite, preventing possible redirect loops.

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -24,7 +24,7 @@ server {
   {% if item.value.multisite | default(false) %}
     {% if item.value.multisite.subdomains | default(false) %}
       rewrite ^/(wp-.*.php)$ /wp/$1 last;
-      rewrite ^/(wp-(content|admin|includes).*) /wp/$1 last;
+      rewrite ^/(wp-(content|admin|includes)/.*) /wp/$1 last;
     {%- else %}
       include wordpress_multisite_subdirectories.conf;
     {%- endif %}


### PR DESCRIPTION
This line in `roles/wordpress-setup/templates/wordpress-site.conf.j2` in the multisite subdomains block:

```
rewrite ^/(wp-(content|admin|includes).*) /wp/$1 last;
```

... can lead to a redirect loop if the user requests `/wp-admin` (sans trailing slash) while not logged in—a common pattern for users trying to reach their dashboard. For such a request, this rewrite rule creates an endless login loop because the `redirect_to` URL gets rewritten to `/wp/wp-admin`.

Matching a trailing slash will allow WordPress to first redirect `/wp-admin` to `/wp-admin/` before this rewrite rule takes effect, preventing the endless login loop:

```
rewrite ^/(wp-(content|admin|includes)/.*) /wp/$1 last;
```