### PR TITLE
Provide a mechanism for custom Nginx includes.

### DIFF
--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -12,6 +12,10 @@
   with_dict: wordpress_sites
   when: item.value.ssl.enabled | default(False)
 
+- name: Create includes.d directories
+  file: path="/etc/nginx/includes.d/{{ item.key }}" state=directory mode=0755
+  with_dict: wordpress_sites
+
 - name: Create WordPress configuration for Nginx
   template: src="wordpress-site.conf.j2"
             dest="/etc/nginx/sites-available/{{ item.key }}.conf"

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -42,6 +42,7 @@ server {
   ssl_certificate_key     /etc/nginx/ssl/{{ item.value.ssl.key | basename }};
   {% endif %}
 
+  include includes.d/{{ item.key }}/*.conf;
   include wordpress.conf;
 }
 


### PR DESCRIPTION
I'm in the process of moving our multisite (subdomain) WP network to Bedrock, and using Bedrock-Ansible for provisioning of dev (and eventually production) instances. Thank you so much for this project!

One thing that would be very useful is a stock way to extend the default Nginx server conf (`roles/wordpress-setup/templates/wordpress-site.conf`). In any large installation, there is always additional configuration needed—for legacy redirects, `proxy_pass`es to other services, etc.

It would be nice to stick with the stock `wordpress-site.conf` (rather than overwrite/adjust it with our own `template` or `lineinfile` tasks). I'd like to propose baking in a wildcard `include` statement that would provide a place for site-specific Nginx server directives.

This PR creates `/etc/nginx/includes.d/[site]/` for each site in `wordpress_sites`, then adds a wildcard include statement to `/etc/nginx/sites-available/[site].conf`. The placement, right above the `include/wordpress.conf`, is designed to allow site-level rewrites in `includes.d` to take precedence.

Of course, the user can ignore this folder and not provide any site-level includes, with no ill effects.

Happy to discuss alternative strategies, or perhaps you've considered something like this and ruled it out. Either way, thanks for Bedrock-Ansible.