### PR TITLE
Allow for custom permissions for shared sources

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -54,6 +54,7 @@ project_templates:
 project_shared_children:
   - path: web/app/uploads
     src: uploads
+    mode: 0775
 
 # The project_environment is a list of environment variables added to the various *_commands
 # Example:

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -55,7 +55,7 @@
   when: item.stat.exists == True
 
 - name: Ensure shared sources are present
-  file: path="{{ deploy_helper.shared_path }}/{{ item.src }}" state="{{ item.type | default('directory') }}"
+  file: path="{{ deploy_helper.shared_path }}/{{ item.src }}" state="{{ item.type | default('directory') }}" mode="{{ item.mode | default('0755') }}"
   with_items: project_shared_children
 
 - name: Ensure shared paths are absent


### PR DESCRIPTION
Current deploys ensure that shared/uploads exists but the directory is left owned by web_user in the web_group group.  The permissions set are 0755 therefore, unless the owner of hhvm/php-fpm is the web_user, uploads aren't possible.  This pull request allows for the setting of looser permissions granting group writeable shared sources.