### PR TITLE
Fix multisite conditional in wordpress-site.conf

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-logs_root: /var/log/nginx/
+logs_root: /var/log/nginx
 nginx_user: www-data
 strip_www: true
 

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -21,7 +21,7 @@ server {
   sendfile off;
   {%- endif %}
 
-  {% if item.value.multisite | default(false) -%}
+  {% if item.value.multisite.enabled | default(false) -%}
     {% if item.value.multisite.subdomains | default(false) -%}
       rewrite ^/(wp-.*.php)$ /wp/$1 last;
       rewrite ^/(wp-(content|admin|includes)/.*) /wp/$1 last;


### PR DESCRIPTION
**Essential fix.** The conditional `item.value.multisite` always evaluates true, so this changes it to `item.value.multisite.enabled`.

**Important fix.** [`logs_root: /var/log/nginx/`](https://github.com/roots/bedrock-ansible/blob/54b8b0797f58be59efd09165b193785ee3e57ffb/roles/nginx/defaults/main.yml#L2) plus [`error_log  {{ logs_root }}/error.log warn;`](https://github.com/roots/bedrock-ansible/blob/54b8b0797f58be59efd09165b193785ee3e57ffb/roles/nginx/templates/nginx.conf.j2#L31) yields double slash `/var/log/nginx//error.log` so I removed trailing slash from the `logs_root` variable, like how there is no trailing slash in [`www_root: /srv/www`](https://github.com/roots/bedrock-ansible/blob/54b8b0797f58be59efd09165b193785ee3e57ffb/group_vars/all#L5).

~~**Aesthetic fix.**~~ (EDIT: this one removed; see comment below) With one combination of variable values, the `wordpress-site.conf.j2` template produces this irregular indentation:
```
server {
    listen 443 ssl spdy;
  
  server_name  staging.example.com;
  access_log   /srv/www/example.com/logs/access.log;
  error_log    /srv/www/example.com/logs/error.log;

  root  /srv/www/example.com/current/web;
  index index.php;

  charset utf-8;

  
  rewrite ^/(wp-.*.php)$ /wp/$1 last;
      rewrite ^/(wp-(content|admin|includes)/.*) /wp/$1 last;
    include ssl.conf;
  include ssl-stapling.conf;
...
```
We can achieve perfect indentation by adding `#jinja2: lstrip_blocks: True` at the top of the template (discovered it after seeing trim_blocks setting [here](https://groups.google.com/forum/#!topic/ansible-project/qHyIjyal_Ic) and [here](http://manpages.ubuntu.com/manpages/trusty/man3/ansible.template.3.html)) and exchanging the various `{%- stuff -%}` with simply `{% stuff %}` (see [whitespace control](http://jinja.pocoo.org/docs/dev/templates/#whitespace-control), ). It seems simpler but maybe there are arguments against this change.