### PR TITLE
Restore strip_www functionality

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,9 +31,10 @@ Vagrant.configure('2') do |config|
 
   hostname, *aliases = wordpress_sites.flat_map { |(_name, site)| site['site_hosts'] }
   config.vm.hostname = hostname
+  www_aliases = ["www.#{hostname}"] + aliases.map { |host| "www.#{host}" }
 
   if Vagrant.has_plugin? 'vagrant-hostsupdater'
-    config.hostsupdater.aliases = aliases
+    config.hostsupdater.aliases = aliases + www_aliases
   else
     puts 'vagrant-hostsupdater missing, please install the plugin:'
     puts 'vagrant plugin install vagrant-hostsupdater'

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -89,3 +89,15 @@ server {
   return 301 https://$host$request_uri;
 }
 {% endif %}
+
+{% for host in item.value.site_hosts if strip_www %}
+server {
+  {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) -%}
+    listen 443 ssl spdy;
+  {% else -%}
+    listen 80;
+  {% endif -%}
+    server_name www.{{ host }};
+    return 301 $scheme://{{ host }}$request_uri;
+}
+{% endfor %}


### PR DESCRIPTION
The `strip_www` feature got bumped to [ssl-only](https://github.com/roots/bedrock-ansible/commit/62fbf956618d17753dfdcf449bc33ad4a6c22bac#diff-0d8f97b3067c54fe0b564ce539dbed5fR48) then [out of existence](https://github.com/roots/bedrock-ansible/commit/dc373fe3b17666285906febaecccea0a7b1521a8#diff-0d8f97b3067c54fe0b564ce539dbed5fL51). This proposes to bring it back. This draws on the [`strip_www: true` default](https://github.com/roots/bedrock-ansible/blob/f2e44d440edea27812b246025897ef90d1a49c2e/roles/nginx/defaults/main.yml#L4) still in `roles/nginx/defaults/main.yml`. I can't say I've been around the server block yet, so please critique the  implementation.