### PR TITLE
Update the Vagrant file with dynamic ANSIBLE_PATH

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 require 'yaml'
 
-ANSIBLE_PATH = '.' # path targeting Ansible directory (relative to Vagrantfile)
+ANSIBLE_PATH = __dir__ # path targeting Ansible directory (relative to Vagrantfile)
 
 # Set Ansible roles_path relative to Ansible directory
 ENV['ANSIBLE_ROLES_PATH'] = File.join(ANSIBLE_PATH, 'vendor', 'roles')


### PR DESCRIPTION
`ANSIBLE_PATH` was relative to the folder where the command was called. This caused error when using Vagrant global commands, which can be called from anywhere. for example `vagrant halt 428b9b5` would produce this error (when in another folder):

```
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /Users/louim/repositories/bedrock-ansible-dev/bedrock-ansible/Vagrantfile
Message: ./group_vars/development file not found. Please set `ANSIBLE_PATH` in Vagrantfile
```

Using [`__dir__`](http://ruby-doc.org/core-2.0.0/Kernel.html#method-i-__dir__) we alway get the path relative to the file itself, not the current folder where the command is executed.